### PR TITLE
qcacld-3.0: Fix compilation with Google clang 15.0.2

### DIFF
--- a/drivers/staging/qcacld-3.0/core/mac/src/include/parser_api.h
+++ b/drivers/staging/qcacld-3.0/core/mac/src/include/parser_api.h
@@ -1052,7 +1052,7 @@ QDF_STATUS populate_dot11f_rrm_ie(struct mac_context *mac,
 				struct pe_session *pe_session);
 
 void populate_mdie(struct mac_context *mac, tDot11fIEMobilityDomain *pDot11f,
-		   uint8_t mdie[]);
+		   uint8_t mdie[SIR_MDIE_SIZE]);
 
 #ifdef WLAN_FEATURE_FILS_SK
 /**


### PR DESCRIPTION
../drivers/staging/qcacld-3.0/core/mac/src/sys/legacy/src/utils/src/parser_api.c:5914:14: error: argument 'mdie' of type 'uint8_t[3]' (aka 'unsigned char[3]') with mismatched bound [-Werror,-Warray-parameter]
                   uint8_t mdie[SIR_MDIE_SIZE])
                           ^
../drivers/staging/qcacld-3.0/core/mac/src/include/parser_api.h:1028:14: note: previously declared as 'uint8_t[]' (aka 'unsigned char[]') here
                   uint8_t mdie[]);